### PR TITLE
[Task - 43971224] Added code changes for Improving the Error Messages being outputted

### DIFF
--- a/MsixCore/msixmgr/ErrorMessageHelper.cpp
+++ b/MsixCore/msixmgr/ErrorMessageHelper.cpp
@@ -10,23 +10,10 @@ namespace ErrorMessageHelper
         HRESULT hresult)
     {
         CString strMessage;
-        WORD facility = HRESULT_FACILITY(hresult);
-        CComPtr<IErrorInfo> iei;
-        if (S_OK == GetErrorInfo(0, &iei) && iei) {
-            // get the error description from the IErrorInfo
-            BSTR bstr = NULL;
-            if (SUCCEEDED(iei->GetDescription(&bstr))) {
-                // append the description to our label
-                strMessage.Append(bstr);
-                // done with BSTR, do manual cleanup
-                SysFreeString(bstr);
-            }
-        }
-        else if (facility == FACILITY_ITF) {
-            // interface specific - no standard mapping available
-            strMessage.Append(_T("FACILITY_ITF - This error is interface specific."));
-        }
-        else {
+        std::wstring errorMessage;
+        try
+        {
+            throw ExceptionCollidedUnwind;
             // use FormatMessage to get a system-defined error message
             LPTSTR lpMsgBuf = NULL;
             DWORD dw = FormatMessage(
@@ -43,9 +30,13 @@ namespace ErrorMessageHelper
                 strMessage.Append(lpMsgBuf);
                 LocalFree(lpMsgBuf);
             }
+            errorMessage = strMessage.GetString();
+        }
+        catch (...)
+        {
+            errorMessage = L"Error Description could not be found";
         }
 
-        std::wstring errorMessage = strMessage.GetString();
         return errorMessage;
     }
 

--- a/MsixCore/msixmgr/ErrorMessageHelper.cpp
+++ b/MsixCore/msixmgr/ErrorMessageHelper.cpp
@@ -4,6 +4,10 @@
 #include <afx.h>
 #include <string>
 
+// Purpose:
+// - This file contains the helper function for extracting the Error Description corresponding to
+//   the HRESULT code being thrown during a particular Workflow execution in MSIXMGR
+
 namespace ErrorMessageHelper
 {
     std::wstring GetErrorMessageFromHRESULT(

--- a/MsixCore/msixmgr/ErrorMessageHelper.cpp
+++ b/MsixCore/msixmgr/ErrorMessageHelper.cpp
@@ -13,7 +13,6 @@ namespace ErrorMessageHelper
         std::wstring errorMessage;
         try
         {
-            throw ExceptionCollidedUnwind;
             // use FormatMessage to get a system-defined error message
             LPTSTR lpMsgBuf = NULL;
             DWORD dw = FormatMessage(

--- a/MsixCore/msixmgr/ErrorMessageHelper.cpp
+++ b/MsixCore/msixmgr/ErrorMessageHelper.cpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include<windows.h>
+#include <afx.h>
+#include <string>
+
+namespace ErrorMessageHelper
+{
+    std::wstring GetErrorMessageFromHRESULT(
+        HRESULT hresult)
+    {
+        CString strMessage;
+        WORD facility = HRESULT_FACILITY(hresult);
+        CComPtr<IErrorInfo> iei;
+        if (S_OK == GetErrorInfo(0, &iei) && iei) {
+            // get the error description from the IErrorInfo
+            BSTR bstr = NULL;
+            if (SUCCEEDED(iei->GetDescription(&bstr))) {
+                // append the description to our label
+                strMessage.Append(bstr);
+                // done with BSTR, do manual cleanup
+                SysFreeString(bstr);
+            }
+        }
+        else if (facility == FACILITY_ITF) {
+            // interface specific - no standard mapping available
+            strMessage.Append(_T("FACILITY_ITF - This error is interface specific."));
+        }
+        else {
+            // use FormatMessage to get a system-defined error message
+            LPTSTR lpMsgBuf = NULL;
+            DWORD dw = FormatMessage(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                FORMAT_MESSAGE_FROM_SYSTEM |
+                FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL,
+                hresult,
+                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                (LPTSTR)&lpMsgBuf,
+                0,
+                NULL);
+            if (dw > 0) {
+                strMessage.Append(lpMsgBuf);
+                LocalFree(lpMsgBuf);
+            }
+        }
+
+        std::wstring errorMessage = strMessage.GetString();
+        return errorMessage;
+    }
+
+}

--- a/MsixCore/msixmgr/ErrorMessageHelper.hpp
+++ b/MsixCore/msixmgr/ErrorMessageHelper.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include<windows.h>
+
+namespace ErrorMessageHelper
+{
+    std::wstring GetErrorMessageFromHRESULT(
+        HRESULT hresult);
+
+}

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -153,37 +153,39 @@ void OutputUnpackFailures(
         std::wcout << "[WARNING] The following packages from " << packageSource << " failed to get unpacked. Please try again: " << std::endl;
         std::wcout << std::endl;
 
+        errorDesc += std::to_wstring(failedPackages.size()) + L" Packages Failed.";
+
         for (int i = 0; i < failedPackages.size(); i++)
         {
             HRESULT hr = failedPackagesErrors.at(i);
 
             std::wstring errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hr);
-            errorDesc += L"HRESULT " + errorCode + L".HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hr);
+            errorDesc += L" (" + std::to_wstring(i) + L") " + L"HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hr);
 
             std::wcout << L"Failed with HRESULT 0x" << std::hex << hr << L" when trying to unpack " << failedPackages.at(i) << std::endl;
 
             if (hr == static_cast<HRESULT>(MSIX::Error::CertNotTrusted))
             {
                 std::wcout << L"Please confirm that the certificate has been installed for this package" << std::endl;
-                errorDesc += L"Please confirm that the certificate has been installed for this package.";
+                errorDesc += L" Please confirm that the certificate has been installed for this package.";
             }
             else if (hr == static_cast<HRESULT>(MSIX::Error::FileWrite))
             {
                 if ((cli.GetFileType() == WVDFileType::VHD || cli.GetFileType() == WVDFileType::VHDX) && cli.GetVHDSize() == 0)
                 {
                     std::wcout << L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space." << std::endl;
-                    errorDesc += L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space.";
+                    errorDesc += L" The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space.";
                 }
                 else
                 {
                     std::wcout << L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space." << std::endl;
-                    errorDesc += L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space.";
+                    errorDesc += L" The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space.";
                 }
             }
             else if (hr == E_INVALIDARG)
             {
                 std::wcout << "Please confirm the given package path is an .appx, .appxbundle, .msix, or .msixbundle file" << std::endl;
-                errorDesc += L"Please confirm the given package path is an .appx, .appxbundle, .msix, or .msixbundle file.";
+                errorDesc += L" Please confirm the given package path is an .appx, .appxbundle, .msix, or .msixbundle file.";
             }
 
             std::wcout << std::endl;

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -173,13 +173,18 @@ void OutputUnpackFailures(
             {
                 if ((cli.GetFileType() == WVDFileType::VHD || cli.GetFileType() == WVDFileType::VHDX) && cli.GetVHDSize() == 0)
                 {
-                    std::wcout << L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the Size of the VHD (larger than 4 times) using the -vhdSize parameter, as file write errors may be caused by insufficient disk space." << std::endl;
-                    errorDesc += L" The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the Size of the VHD (larger than 4 times) using the -vhdSize parameter, as file write errors may be caused by insufficient disk space.";
+                    std::wcout << L"File write error encountered. This may be caused by insufficient disk space. The tool tried with 4 times package size as VHD(X) size. Please try again with -vhdSize parameter greater than 4 times the package size in MB." << std::endl;
+                    errorDesc += L" File write error encountered. This may be caused by insufficient disk space. The tool tried with 4 times package size as VHD(X) size. Please try again with -vhdSize parameter greater than 4 times the package size in MB.";
+                }
+                else if (cli.GetFileType() == WVDFileType::VHD || cli.GetFileType() == WVDFileType::VHDX)
+                {
+                    std::wcout << L"File write error encountered. This may be caused by insufficient disk space. Please try again with a larger VHD(X) size." << std::endl;
+                    errorDesc += L" File write error encountered. This may be caused by insufficient disk space. Please try again with a larger VHD(X) size.";
                 }
                 else
                 {
-                    std::wcout << L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space." << std::endl;
-                    errorDesc += L" The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space.";
+                    std::wcout << L"File write error encountered." << std::endl;
+                    errorDesc += L" File write error encountered.";
                 }
             }
             else if (hr == E_INVALIDARG)

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -25,6 +25,7 @@
 #include "MsixErrors.hpp"
 #include <filesystem>
 #include "msixmgrTraceLogging.hpp"
+#include "ErrorMessageHelper.hpp"
 
 #include <msixmgrActions.hpp>
 using namespace std;
@@ -128,7 +129,9 @@ void OutputUnpackFailures(
     _In_ std::wstring packageSource,
     _In_ std::vector<std::wstring> skippedFiles,
     _In_ std::vector<std::wstring> failedPackages,
-    _In_ std::vector<HRESULT> failedPackagesErrors)
+    _In_ std::vector<HRESULT> failedPackagesErrors,
+    _In_ CommandLineInterface cli,
+    _In_ std::wstring &errorDesc)
 {
     if (!skippedFiles.empty())
     {
@@ -154,18 +157,33 @@ void OutputUnpackFailures(
         {
             HRESULT hr = failedPackagesErrors.at(i);
 
+            std::wstring errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hr);
+            errorDesc += L"HRESULT " + errorCode + L".HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hr);
+
             std::wcout << L"Failed with HRESULT 0x" << std::hex << hr << L" when trying to unpack " << failedPackages.at(i) << std::endl;
+
             if (hr == static_cast<HRESULT>(MSIX::Error::CertNotTrusted))
             {
                 std::wcout << L"Please confirm that the certificate has been installed for this package" << std::endl;
+                errorDesc += L"Please confirm that the certificate has been installed for this package.";
             }
             else if (hr == static_cast<HRESULT>(MSIX::Error::FileWrite))
             {
-                std::wcout << L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space." << std::endl;
+                if ((cli.GetFileType() == WVDFileType::VHD || cli.GetFileType() == WVDFileType::VHDX) && cli.GetVHDSize() == 0)
+                {
+                    std::wcout << L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space." << std::endl;
+                    errorDesc += L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space.";
+                }
+                else
+                {
+                    std::wcout << L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space." << std::endl;
+                    errorDesc += L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space.";
+                }
             }
             else if (hr == E_INVALIDARG)
             {
                 std::wcout << "Please confirm the given package path is an .appx, .appxbundle, .msix, or .msixbundle file" << std::endl;
+                errorDesc += L"Please confirm the given package path is an .appx, .appxbundle, .msix, or .msixbundle file.";
             }
 
             std::wcout << std::endl;
@@ -229,7 +247,7 @@ int main(int argc, char * argv[])
             if (FAILED(hrCreatePackageManager))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreatePackageManager);
-                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreatePackageManager);
 
 
                 // Telemetry : Workflow Log
@@ -259,9 +277,12 @@ int main(int argc, char * argv[])
                 if (FAILED(hrAddPackage))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrAddPackage);
-                    errorDesc = L"Failed Add Package Operation. HRESULT " + errorCode + L".";
+                    errorDesc = L"Failed Add Package Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrAddPackage);
 
                     std::wcout << GetStringResource(IDS_STRING_FAILED_REQUEST) << " " << std::hex << hrAddPackage << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrAddPackage);
+                    std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -295,7 +316,7 @@ int main(int argc, char * argv[])
                             hrHRESULTFromWin32 = HRESULT_FROM_WIN32(GetLastError());
 
                             errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrHRESULTFromWin32);
-                            errorDesc = L"Failed Add Package Operation. HRESULT " + errorCode + L".";
+                            errorDesc = L"Failed Add Package Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrHRESULTFromWin32);
 
                             // Telemetry : Workflow Log
                             QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -331,7 +352,7 @@ int main(int argc, char * argv[])
                     if (FAILED(hrShowUI))
                     {
                         errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrShowUI);
-                        errorDesc = L"Failed Show UI Operation for Add Package Operation. HRESULT " + errorCode + L".";
+                        errorDesc = L"Failed Show UI Operation for Add Package Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrShowUI);
 
                         // Telemetry : Workflow Log
                         QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -376,7 +397,7 @@ int main(int argc, char * argv[])
             if (FAILED(hrCreatePackageManager))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreatePackageManager);
-                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreatePackageManager);
 
                 // Telemetry : Workflow Log
                 QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -391,9 +412,12 @@ int main(int argc, char * argv[])
             if (FAILED(hrRemovePackage))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrRemovePackage);
-                errorDesc = L"Failed Remove Package Operation. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed Remove Package Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrRemovePackage);
 
                 std::wcout << GetStringResource(IDS_STRING_FAILED_REQUEST) << " " << std::hex << hrRemovePackage << std::endl;
+                std::wcout << std::endl;
+                std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrRemovePackage);
+                std::wcout << std::endl;
 
                 // Telemetry : Workflow Log
                 QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -422,7 +446,7 @@ int main(int argc, char * argv[])
             if (FAILED(hrCreatePackageManager))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreatePackageManager);
-                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed creation of Package Manager Object. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreatePackageManager);
 
                 // Telemetry : Workflow Log
                 QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -439,7 +463,7 @@ int main(int argc, char * argv[])
             if (FAILED(hrFindPackage))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrFindPackage);
-                errorDesc = L"Failed Find Package Operation. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed Find Package Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrFindPackage);
 
                 // Telemetry : Workflow Log
                 QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -494,10 +518,12 @@ int main(int argc, char * argv[])
                 if (rootDirectory.empty() || fileType == WVDFileType::NotSpecified)
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                    errorDesc = L"Creating a file with the -create option requires both a -rootDirectory and -fileType. HRESULT " + errorCode + L".";
+                    errorDesc = L"Creating a file with the -create option requires both a -rootDirectory and -fileType. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                     std::wcout << std::endl;
-                    std::wcout << "Creating a file with the -create option requires both a -rootDirectory and -fileType" << std::endl;
+                    std::wcout << "Creating a file with the -create option requires both a -rootDirectory and -fileType." << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -510,10 +536,12 @@ int main(int argc, char * argv[])
                 if (!EndsWith(unpackDestination, L".cim"))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                    errorDesc = L"Invalid CIM file name. File name must have .cim file extension. HRESULT " + errorCode + L".";
+                    errorDesc = L"Invalid CIM file name. File name must have .cim file extension. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                     std::wcout << std::endl;
-                    std::wcout << "Invalid CIM file name. File name must have .cim file extension" << std::endl;
+                    std::wcout << "Invalid CIM file name. File name must have .cim file extension." << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -533,7 +561,7 @@ int main(int argc, char * argv[])
                 if (FAILED(hrCreateGUIDString))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreateGUIDString);
-                    errorDesc = L"Failed UniqueGuid creation for tempDirPathString for CIM file. HRESULT " + errorCode + L".";
+                    errorDesc = L"Failed UniqueGuid creation for tempDirPathString for CIM file. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreateGUIDString);
 
                     // Telemetry : Workflow Log
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -553,11 +581,13 @@ int main(int argc, char * argv[])
                 if (!createTempDirResult)
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_UNEXPECTED);
-                    errorDesc = L"Failed to create temp directory. This may occur when the directory path already exists. Please try again. HRESULT " + errorCode + L".";
+                    errorDesc = L"Failed to create temp directory. This may occur when the directory path already exists. Please try again. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_UNEXPECTED);
 
                     std::wcout << std::endl;
                     std::wcout << "Failed to create temp directory " << tempDirPathString << std::endl;
                     std::wcout << "This may occur when the directory path already exists. Please try again."  << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_UNEXPECTED);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -570,7 +600,7 @@ int main(int argc, char * argv[])
                 if (createDirectoryErrorCode.value() != 0)
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_UNEXPECTED);
-                    errorDesc = L"Creation of temp directory failed with error: " + std::to_wstring(createDirectoryErrorCode.value()) + L". Error Message: " + utf8_to_utf16(createDirectoryErrorCode.message()) + L". Please try again. HRESULT " + errorCode + L".";
+                    errorDesc = L"Creation of temp directory failed with error: " + std::to_wstring(createDirectoryErrorCode.value()) + L". Error Message: " + utf8_to_utf16(createDirectoryErrorCode.message()) + L". Please try again. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_UNEXPECTED);
 
                     // Again, we expect that the creation of the temp directory will fail very rarely. Output the exception
                     // and have the user try again.
@@ -578,6 +608,8 @@ int main(int argc, char * argv[])
                     std::wcout << "Creation of temp directory " << tempDirPathString << " failed with error: " << createDirectoryErrorCode.value() << std::endl;
                     std::cout << "Error message: " << createDirectoryErrorCode.message() << std::endl;
                     std::wcout << "Please try again." << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_UNEXPECTED);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -600,7 +632,7 @@ int main(int argc, char * argv[])
                 if (FAILED(hrUnpackToTempDir))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnpackToTempDir);
-                    errorDesc = L"Failed to Unpack in Temp Directory for CIM flow. HRESULT " + errorCode + L".";
+                    errorDesc = L"Failed to Unpack in Temp Directory for CIM flow. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnpackToTempDir);
 
                     // Telemetry : Workflow Log
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -626,10 +658,12 @@ int main(int argc, char * argv[])
                 if (FAILED(hrCreateCIM))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreateCIM);
-                    errorDesc = L"Creating the CIM file failed. HRESULT " + errorCode + L".";
+                    errorDesc = L"Creating the CIM file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreateCIM);
 
                     std::wcout << std::endl;
                     std::wcout << "Creating the CIM file  " << unpackDestination << " failed with HRESULT 0x" << std::hex << hrCreateCIM << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreateCIM);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -645,12 +679,14 @@ int main(int argc, char * argv[])
                     std::wcout << "Successfully created the CIM file: " << unpackDestination << std::endl;
                     std::wcout << std::endl;
 
-                    OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors);
+                    OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors, cli, errorDesc);
 
                     // Telemetry : Workflow Log
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
-                    msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", L"");
+                    msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
+
+                    return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                 }
                  
             }
@@ -662,10 +698,12 @@ int main(int argc, char * argv[])
                     if (!(EndsWith(unpackDestination, L".vhd") || (EndsWith(unpackDestination, L".vhdx"))))
                     {
                         errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                        errorDesc = L"Invalid VHD file name. File name must have .vhd or .vhdx file extension. HRESULT " + errorCode + L".";
+                        errorDesc = L"Invalid VHD file name. File name must have .vhd or .vhdx file extension. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                         std::wcout << std::endl;
-                        std::wcout << "Invalid VHD file name. File name must have .vhd or .vhdx file extension" << std::endl;
+                        std::wcout << "Invalid VHD file name. File name must have .vhd or .vhdx file extension." << std::endl;
+                        std::wcout << std::endl;
+                        std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                         std::wcout << std::endl;
 
                         // Telemetry : Workflow Log
@@ -690,10 +728,13 @@ int main(int argc, char * argv[])
                         if (FAILED(hrCreateVHD))
                         {
                             errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrCreateVHD);
-                            errorDesc = L"Creation of VHD(X) file failed. HRESULT " + errorCode + L".";
+                            errorDesc = L"Creation of VHD(X) file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreateVHD);
 
                             std::wcout << std::endl;
                             std::wcout << "Creating the VHD(X) file  " << unpackDestination << " failed with HRESULT 0x" << std::hex << hrCreateVHD << std::endl;
+                            std::wcout << std::endl;
+                            std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrCreateVHD);
+                            std::wcout << std::endl;
 
                             if (hrCreateVHD != HRESULT_FROM_WIN32(ERROR_FILE_EXISTS))
                             {
@@ -739,7 +780,7 @@ int main(int argc, char * argv[])
                         if (FAILED(hrUnpackToVHD))
                         {
                             errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnpackToVHD);
-                            errorDesc = L"Failed unpack to the mounted vhd(x). HRESULT " + errorCode + L".";
+                            errorDesc = L"Failed unpack to the mounted vhd(x). HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnpackToVHD);
 
                             // Telemetry : Workflow Log
                             QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -753,15 +794,17 @@ int main(int argc, char * argv[])
                         if (FAILED(hrUnmount))
                         {
                             errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnmount);
-                            errorDesc = L"Successful Unpack to mounted vhd(x). Unmounting the VHD failed. Ignoring as non-fatal error. HRESULT " + errorCode + L".";
+                            errorDesc = L"Successful Unpack to mounted vhd(x). Unmounting the VHD failed. Ignoring as non-fatal error. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmount);
 
                             std::wcout << std::endl;
                             std::wcout << "Unmounting the VHD  " << unpackDestination << " failed with HRESULT 0x" << std::hex << hrCreateVHD << std::endl;
                             std::wcout << "Ignoring as non-fatal error.." << std::endl;
                             std::wcout << std::endl;
+                            std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmount);
+                            std::wcout << std::endl;
                         }
 
-                        OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors);
+                        OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors, cli, errorDesc);
 
                         std::wcout << std::endl;
                         std::wcout << "Finished unpacking packages to: " << unpackDestination << std::endl;
@@ -770,7 +813,9 @@ int main(int argc, char * argv[])
                         // Telemetry : Workflow Log
                         QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                         workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
-                        msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, errorCode.c_str(), errorDesc.c_str());
+                        msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
+
+                        return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                     }
                 }
                 else
@@ -787,7 +832,7 @@ int main(int argc, char * argv[])
                     if (FAILED(hrUnpackToFolder))
                     {
                         errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnpackToFolder);
-                        errorDesc = L"Failed unpack to the given folder or given VHD(X). HRESULT " + errorCode + L".";
+                        errorDesc = L"Failed unpack to the given folder or given VHD(X). HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnpackToFolder);
 
                         // Telemetry : Workflow Log
                         QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -801,12 +846,14 @@ int main(int argc, char * argv[])
                     std::wcout << "Finished unpacking packages to: " << unpackDestination << std::endl;
                     std::wcout << std::endl;
 
-                    OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors);
+                    OutputUnpackFailures(packageSourcePath, skippedFiles, failedPackages, failedPackagesErrors, cli, errorDesc);
 
                     // Telemetry : Workflow Log
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
-                    msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", L"");
+                    msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
+
+                    return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                 }
             }
             return S_OK;
@@ -825,7 +872,7 @@ int main(int argc, char * argv[])
             if (FAILED(hrApplyACLs))
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrApplyACLs);
-                errorDesc = L"Failed ApplyACLs Operation. HRESULT " + errorCode + L".";
+                errorDesc = L"Failed ApplyACLs Operation. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrApplyACLs);
 
                 // Telemetry : Workflow Log
                 QueryPerformanceCounter(&msixMgrLoad_EndCounter);
@@ -852,10 +899,12 @@ int main(int argc, char * argv[])
             if (cli.GetMountImagePath().empty())
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                errorDesc = L"Please provide the path to the image you would like to mount. HRESULT " + errorCode + L".";
+                errorDesc = L"Please provide the path to the image you would like to mount. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                 std::wcout << std::endl;
                 std::wcout << "Please provide the path to the image you would like to mount." << std::endl;
+                std::wcout << std::endl;
+                std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                 std::wcout << std::endl;
 
                 // Telemetry : Workflow Log
@@ -873,10 +922,12 @@ int main(int argc, char * argv[])
                 if (FAILED(hrMountCIM))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrMountCIM);
-                    errorDesc = L"Mounting the CIM file failed. HRESULT " + errorCode + L".";
+                    errorDesc = L"Mounting the CIM file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrMountCIM);
 
                     std::wcout << std::endl;
                     std::wcout << "Mounting the CIM file  " << cli.GetMountImagePath() << " failed with HRESULT 0x" << std::hex << hrMountCIM << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrMountCIM);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -911,10 +962,12 @@ int main(int argc, char * argv[])
                 if (FAILED(hrMountVHD))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrMountVHD);
-                    errorDesc = L"Mounting the VHD(X) file failed. HRESULT " + errorCode + L".";
+                    errorDesc = L"Mounting the VHD(X) file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrMountVHD);
 
                     std::wcout << std::endl;
                     std::wcout << "Mounting the VHD(X) file  " << cli.GetMountImagePath() << " failed with HRESULT 0x" << std::hex << hrMountVHD << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrMountVHD);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -942,10 +995,12 @@ int main(int argc, char * argv[])
             else
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(ERROR_NOT_SUPPORTED);
-                errorDesc = L"Please specify one of the following supported file types for the -MountImage command: {VHD, VHDX, CIM}. HRESULT " + errorCode + L".";
+                errorDesc = L"Please specify one of the following supported file types for the -MountImage command: {VHD, VHDX, CIM}. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(ERROR_NOT_SUPPORTED);
 
                 std::wcout << std::endl;
                 std::wcout << "Please specify one of the following supported file types for the -MountImage command: {VHD, VHDX, CIM}" << std::endl;
+                std::wcout << std::endl;
+                std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(ERROR_NOT_SUPPORTED);
                 std::wcout << std::endl;
 
                 // Telemetry : Workflow Log
@@ -968,12 +1023,14 @@ int main(int argc, char * argv[])
                 if (cli.GetVolumeId().empty() && cli.GetMountImagePath().empty())
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                    errorDesc = L"To unmount an CIM image, please provide either the CIM file path or the volume the image was mounted to. HRESULT " + errorCode + L".";
+                    errorDesc = L"To unmount an CIM image, please provide either the CIM file path or the volume the image was mounted to. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                     std::wcout << std::endl;
                     std::wcout << "To unmount an CIM image, please provide either the CIM file path or the volume the image was mounted to." << std::endl;
                     std::wcout << "The CIM file path can be specified using the -imagepath option." << std::endl;
                     std::wcout << "The volume can be specified using the -volumeId option." << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -989,10 +1046,13 @@ int main(int argc, char * argv[])
                 if (FAILED(hrUnmountCIM))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnmountCIM);
-                    errorDesc = L"Unmounting the CIM file failed. HRESULT " + errorCode + L".";
+                    errorDesc = L"Unmounting the CIM file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmountCIM);
 
                     std::wcout << std::endl;
                     std::wcout << "Unmounting the CIM " << " failed with HRESULT 0x" << std::hex << hrUnmountCIM << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmountCIM);
+                    std::wcout << std::endl;
 
                     // ERROR_NOT_FOUND may be returned if only the mount image path but not the volume id was provided
                     // and msixmgr was unable to find the volume id associated with a given image path.
@@ -1045,10 +1105,12 @@ int main(int argc, char * argv[])
                 if (cli.GetMountImagePath().empty())
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(E_INVALIDARG);
-                    errorDesc = L"Please provide the path to the image you would like to unmount. HRESULT " + errorCode + L".";
+                    errorDesc = L"Please provide the path to the image you would like to unmount. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
 
                     std::wcout << std::endl;
                     std::wcout << "Please provide the path to the image you would like to unmount." << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(E_INVALIDARG);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -1064,10 +1126,12 @@ int main(int argc, char * argv[])
                 if (FAILED(hrUnmountVHD))
                 {
                     errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hrUnmountVHD);
-                    errorDesc = L"Unmounting the VHD file failed. HRESULT " + errorCode + L".";
+                    errorDesc = L"Unmounting the VHD file failed. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmountVHD);
 
                     std::wcout << std::endl;
                     std::wcout << "Unmounting the VHD " << cli.GetMountImagePath() << " failed with HRESULT 0x" << std::hex << hrUnmountVHD << std::endl;
+                    std::wcout << std::endl;
+                    std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(hrUnmountVHD);
                     std::wcout << std::endl;
 
                     // Telemetry : Workflow Log
@@ -1092,10 +1156,12 @@ int main(int argc, char * argv[])
             else
             {
                 errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(ERROR_NOT_SUPPORTED);
-                errorDesc = L"Please specify one of the following supported file types for the -UnmountImage command: {VHD, VHDX, CIM}. HRESULT " + errorCode + L".";
+                errorDesc = L"Please specify one of the following supported file types for the -UnmountImage command: {VHD, VHDX, CIM}. HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(ERROR_NOT_SUPPORTED);
 
                 std::wcout << std::endl;
                 std::wcout << "Please specify one of the following supported file types for the -UnmountImage command: {VHD, VHDX, CIM}" << std::endl;
+                std::wcout << std::endl;
+                std::wcout << "HRESULT - " << errorCode << ". HRESULT Desc - " << ErrorMessageHelper::GetErrorMessageFromHRESULT(ERROR_NOT_SUPPORTED);
                 std::wcout << std::endl;
 
                 // Telemetry : Workflow Log

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -687,8 +687,6 @@ int main(int argc, char * argv[])
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                     msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
-
-                    return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                 }
                  
             }
@@ -816,8 +814,6 @@ int main(int argc, char * argv[])
                         QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                         workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                         msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
-
-                        return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                     }
                 }
                 else
@@ -854,8 +850,6 @@ int main(int argc, char * argv[])
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                     msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", errorDesc.c_str());
-
-                    return failedPackagesErrors.empty() ? S_OK : failedPackagesErrors.back();
                 }
             }
             return S_OK;

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -173,8 +173,8 @@ void OutputUnpackFailures(
             {
                 if ((cli.GetFileType() == WVDFileType::VHD || cli.GetFileType() == WVDFileType::VHDX) && cli.GetVHDSize() == 0)
                 {
-                    std::wcout << L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space." << std::endl;
-                    errorDesc += L" The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the VHDSize (larger than 4 times), as file write errors may be caused by insufficient disk space.";
+                    std::wcout << L"The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the Size of the VHD (larger than 4 times) using the -vhdSize parameter, as file write errors may be caused by insufficient disk space." << std::endl;
+                    errorDesc += L" The tool encountered a file write error. Since VHDSize parameter was not specified, the tool tried with default VHDSize of 4 times the size of the package and operation got failed. Please try again by specifying the Size of the VHD (larger than 4 times) using the -vhdSize parameter, as file write errors may be caused by insufficient disk space.";
                 }
                 else
                 {

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -153,14 +153,14 @@ void OutputUnpackFailures(
         std::wcout << "[WARNING] The following packages from " << packageSource << " failed to get unpacked. Please try again: " << std::endl;
         std::wcout << std::endl;
 
-        errorDesc += std::to_wstring(failedPackages.size()) + L" Packages Failed.";
+        errorDesc += L" " + std::to_wstring(failedPackages.size()) + L" Packages Failed.";
 
         for (int i = 0; i < failedPackages.size(); i++)
         {
             HRESULT hr = failedPackagesErrors.at(i);
 
             std::wstring errorCode = msixmgrTraceLogging::GetErrorCodeFromHRESULT(hr);
-            errorDesc += L" (" + std::to_wstring(i) + L") " + L"HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hr);
+            errorDesc += L" (" + std::to_wstring(i+1) + L") " + L"HRESULT " + errorCode + L". HRESULT Desc - " + ErrorMessageHelper::GetErrorMessageFromHRESULT(hr);
 
             std::wcout << L"Failed with HRESULT 0x" << std::hex << hr << L" when trying to unpack " << failedPackages.at(i) << std::endl;
 

--- a/MsixCore/msixmgr/msixmgr.vcxproj
+++ b/MsixCore/msixmgr/msixmgr.vcxproj
@@ -42,8 +42,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -230,6 +231,7 @@ del "$(OutDir)msixmgr_LN.exe"
     <ClInclude Include="ApplyACLsProvider.hpp" />
     <ClInclude Include="CIMProvider.hpp" />
     <ClInclude Include="CommandLineInterface.hpp" />
+    <ClInclude Include="ErrorMessageHelper.hpp" />
     <ClInclude Include="InstallUI.hpp" />
     <ClInclude Include="msixmgrTelemetry.hpp" />
     <ClInclude Include="msixmgrTraceLogging.hpp" />
@@ -242,6 +244,7 @@ del "$(OutDir)msixmgr_LN.exe"
   <ItemGroup>
     <ClCompile Include="ApplyACLsProvider.cpp" />
     <ClCompile Include="CIMProvider.cpp" />
+    <ClCompile Include="ErrorMessageHelper.cpp" />
     <ClCompile Include="InstallUI.cpp" />
     <ClCompile Include="CommandLineInterface.cpp" />
     <ClCompile Include="msixmgrTelemetry.cpp" />

--- a/MsixCore/msixmgr/msixmgr.vcxproj.filters
+++ b/MsixCore/msixmgr/msixmgr.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="msixmgrTraceLogging.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ErrorMessageHelper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="InstallUI.cpp">
@@ -81,6 +84,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="msixmgrTraceLogging.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ErrorMessageHelper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
### Description

## Why the change been made ?
On every execution, the MSIXMGR Tool generates a Response which denotes whether it is a successful execution (S_OK) or an erroneous execution (some error code). During an erroneous execution, the tool generates an HRESULT code which indicates the error that has occurred and also a custom message that indicates the information related to that particular flow. 

There are few shortcomings with the current way of outputting the error message to the user – 

- The Error Messages are sometimes specific to the Execution flow and we are not outputting the details related to the HRESULT code, which might give deeper information regarding the failure/error that has occurred. 

For example, while unpacking to a VHDX, the error currently being thrown is “Creating the VHDX failed. HRESULT 0x80889382”, but we are not showing the underlying reason for the failure and the description for the HRESULT. 

- Due to recent changes due to the VHDSize parameter (making it optional), the error messages being outputted needs to be changed to comply with the new changes. (Details in next section)

## What change has been made ?
1) Added a middleware library to extract the Error Description corresponding to the HRESULT code.
2) Appending the Error Desc corresponding to HRESULT code to Telemetry Output and to Console Output
3) Handling the Error Messaging for the code changes done for VHD Size parameter

## Testing 
Tested every workflow in the MSIXMGR Tool by running the Tool and verifying the output.