### PR TITLE
[Task - 44528959] Added code changes to resolve the Github Bug

### DIFF
--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -651,6 +651,8 @@ int main(int argc, char * argv[])
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                     msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", L"");
+
+                    return failedPackagesErrors.size() != 0 ? failedPackagesErrors.back() : S_OK;
                 }
                  
             }
@@ -771,6 +773,8 @@ int main(int argc, char * argv[])
                         QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                         workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                         msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, errorCode.c_str(), errorDesc.c_str());
+
+                        return failedPackagesErrors.size() != 0 ? failedPackagesErrors.back() : S_OK;
                     }
                 }
                 else
@@ -807,6 +811,8 @@ int main(int argc, char * argv[])
                     QueryPerformanceCounter(&msixMgrLoad_EndCounter);
                     workflowElapsedTime = msixmgrTraceLogging::CalcWorkflowElapsedTime(msixMgrLoad_StartCounter, msixMgrLoad_EndCounter, msixMgrLoad_Frequency);
                     msixmgrTraceLogging::TraceLogWorkflow(workflowId.c_str(), cli.GetOperationTypeAsString().c_str(), true, workflowElapsedTime, L"", L"");
+
+                    return failedPackagesErrors.size() != 0 ? failedPackagesErrors.back() : S_OK;
                 }
             }
             return S_OK;


### PR DESCRIPTION
### Description

## Why the change been made ?
Link to the Bug - [[BUG] msixmgr does not return bad status when unpack fails due to insufficient disk space · Issue #507 · microsoft/msix-packaging (github.com)](https://github.com/microsoft/msix-packaging/issues/507) 

As per the above GitHub issue, whenever we are trying to unpack multiple packages present in a directory, the unpack might fail for some of the packages. In this case the Response HRESULT code being returned should be one of the Erroneous HRESULT code, but the tool is currently returning a successful Response for the execution. 

The User is not able to find the LAST HRESULT CODE using the $LASTEXITCODE command in Powershell.

## What change has been made ?
In the above case we will be returning the last HRESULT code that has been encountered while unpacking the set of packages as the Process output.  
Added code changes for the same.

## Testing 
Tested the concerned workflow in the MSIXMGR Tool by running the Tool and verifying the output.